### PR TITLE
contribTo in the total column is now blank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
-* Switched to specific release of base Docker image to avoid accidental breaking changes
-  in base Docker image.
 
 ### Deprecated
 
@@ -18,6 +16,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+
+## [1.12.3] - 2022-02-22
+
+### Changed
+* Switched to specific release of base Docker image to avoid accidental breaking changes
+  in base Docker image.
+
+### Fixed
+* Total count of repositories (other than own) contributed to will now show as
+  a blank spot on the SVG. Previously reported values were highly inaccurate, and
+  cannot be computed accurately at the present time due to unavailability of
+  necessary data from the GitHub GraphQL API.
+  
 
 ## [1.12.2] - 2022-02-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2022-02-18
+## [Unreleased] - 2022-02-22
 
 ### Added
 
 ### Changed
+* Switched to specific release of base Docker image to avoid accidental breaking changes
+  in base Docker image.
 
 ### Deprecated
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-# Copyright (c) 2021 Vincent A. Cicirello
+# Copyright (c) 2021-2022 Vincent A. Cicirello
 # https://www.cicirello.org/
 # Licensed under the MIT License
 
-# The base image is pyaction:4, which is python:3-slim, plus the GitHub CLI (gh).
-FROM ghcr.io/cicirello/pyaction:4
+# The base image is pyaction, which is python slim, plus the GitHub CLI (gh).
+FROM ghcr.io/cicirello/pyaction:4.2.0
 
 # Copy the GraphQl queries and python source into the container.
 COPY src /

--- a/README.md
+++ b/README.md
@@ -490,6 +490,9 @@ The contributions statistics in the image include the following.
 | `contribTo` | Contributed To | number of repositories owned by others that you have contributed to |
 | `private` | Private Contributions | number of private contributions if you have shared them via your GitHub settings |
 
+Note that due to limitations in the available data from the GitHub GraphQL API, the
+"Total" column for `contribTo` on the generated SVG is deliberately blank.
+
 Please note that GitHub's "restrictedContributionsCount" (which is your private contributions
 count) doesn't distinguish the type of contributions, so we cannot simply add
 these to the specific counts by type. 

--- a/src/StatConfig.py
+++ b/src/StatConfig.py
@@ -1,7 +1,7 @@
 #
 # user-statistician: Github action for generating a user stats card
 #
-# Copyright (c) 2021 Vincent A Cicirello
+# Copyright (c) 2021-2022 Vincent A Cicirello
 # https://www.cicirello.org/
 #
 # MIT License
@@ -923,7 +923,7 @@ statLabels = {
 
     "contribTo" : {
         "icon" : '<path fill="{0}" fill-rule="evenodd" d="M1 2.5A2.5 2.5 0 013.5 0h8.75a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0V1.5h-8a1 1 0 00-1 1v6.708A2.492 2.492 0 013.5 9h3.25a.75.75 0 010 1.5H3.5a1 1 0 100 2h5.75a.75.75 0 010 1.5H3.5A2.5 2.5 0 011 11.5v-9zm13.23 7.79a.75.75 0 001.06-1.06l-2.505-2.505a.75.75 0 00-1.06 0L9.22 9.229a.75.75 0 001.06 1.061l1.225-1.224v6.184a.75.75 0 001.5 0V9.066l1.224 1.224z"/>',
-        "totalIsLowerBound" : True,
+        "totalIsLowerBound" : False, 
         "label" : {
             "en" : "Contributed To",
             "it" : "Contribuito A",

--- a/src/Statistician.py
+++ b/src/Statistician.py
@@ -1,7 +1,7 @@
 #
 # user-statistician: Github action for generating a user stats card
 # 
-# Copyright (c) 2021 Vincent A Cicirello
+# Copyright (c) 2021-2022 Vincent A Cicirello
 # https://www.cicirello.org/
 #
 # MIT License
@@ -189,6 +189,10 @@ class Statistician :
         ownedRepositories = repoStats[0]["totalCount"]
         
         # Count num repos owned by someone else that the user has contributed to
+        # NOTE: It doesn't appear that it is currently possible through any query
+        # or combination of queries to actually compute this other than for the most recent
+        # year's data. Keeping the query in, but changing to leave that stat blank in
+        # the SVG.
         repositoriesContributedTo = sum(1 for page in reposContributedToStats if page["nodes"] != None for repo in page["nodes"] if repo["owner"]["login"] != self._login)
         
         self._contrib = {
@@ -196,7 +200,9 @@ class Statistician :
             "issues" : [pastYearData["totalIssueContributions"], issues],
             "prs" : [pastYearData["totalPullRequestContributions"], pullRequests],
             "reviews" : [pastYearData["totalPullRequestReviewContributions"], 0],
-            "contribTo" : [pastYearData["repositoriesContributedTo"], repositoriesContributedTo],
+            # See comment above for reason for this change.
+            #"contribTo" : [pastYearData["repositoriesContributedTo"], repositoriesContributedTo],
+            "contribTo" : [pastYearData["repositoriesContributedTo"]],
             "private" : [pastYearData["restrictedContributionsCount"], 0]
             }
 

--- a/src/StatsImageGenerator.py
+++ b/src/StatsImageGenerator.py
@@ -1,7 +1,7 @@
 #
 # user-statistician: Github action for generating a user stats card
 # 
-# Copyright (c) 2021 Vincent A Cicirello
+# Copyright (c) 2021-2022 Vincent A Cicirello
 # https://www.cicirello.org/
 #
 # MIT License

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,6 +1,6 @@
 # user-statistician: Github action for generating a user stats card
 # 
-# Copyright (c) 2021 Vincent A Cicirello
+# Copyright (c) 2021-2022 Vincent A Cicirello
 # https://www.cicirello.org/
 #
 # MIT License
@@ -347,7 +347,7 @@ class TestSomething(unittest.TestCase) :
         self.assertEqual(315, stats._contrib["reviews"][0])
         self.assertEqual(315, stats._contrib["reviews"][1])
         self.assertEqual(3, stats._contrib["contribTo"][0])
-        self.assertEqual(8, stats._contrib["contribTo"][1])
+        #self.assertEqual(8, stats._contrib["contribTo"][1])
         self.assertEqual(105, stats._contrib["private"][0])
         self.assertEqual(105, stats._contrib["private"][1])
 
@@ -385,7 +385,7 @@ class TestSomething(unittest.TestCase) :
         self.assertEqual(315, stats._contrib["reviews"][0])
         self.assertEqual(315, stats._contrib["reviews"][1])
         self.assertEqual(3, stats._contrib["contribTo"][0])
-        self.assertEqual(8, stats._contrib["contribTo"][1])
+        #self.assertEqual(8, stats._contrib["contribTo"][1])
         self.assertEqual(105, stats._contrib["private"][0])
         self.assertEqual(105, stats._contrib["private"][1])
         self.assertEqual(0, stats._languages["totalSize"])


### PR DESCRIPTION
## Summary
Due to limitations in the available data from the API, contribTo in the total column is now blank on purpose. Previously reported values are significantly inaccurate. Less than ideal solution, but blank is better than far off. Users can disable that stat altogether if they wish.

## Closing Issues
Closes #109 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
