### PR TITLE
Added new themes based on GitHub's newer themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2022-05-01
+## [Unreleased] - 2022-05-02
 
 ### Added
+* New themes added to correspond to all of GitHub's themes, including:
+  * dark-high-contrast
+  * light-high-contrast
+  * dark-colorblind
+  * light-colorblind
+  * dark-tritanopia
+  * light-tritanopia
 
 ### Changed
 * Bumped base Docker image cicirello/pyaction from 4.2.0 to 4.3.1.
@@ -17,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 * Fixed margin calculation when most starred, most forked, or featured repo has long name.
-* Adjusted existing themes based on newer versions of corresponding GitHub themes.
+* Adjusted existing themes (dark, light, dark-dimmed) based on newer versions of corresponding GitHub themes.
 
 
 ## [1.12.3] - 2022-02-22

--- a/README.md
+++ b/README.md
@@ -668,15 +668,34 @@ then you can pass: `language-animation-speed: 5`.  The input must be an integer.
 
 The `colors` input enables you to either select from a set of
 built-in color themes, or to define your own set of custom colors.
-At the present time, there are three built-in themes: `light`, `dark`, and
-`dark-dimmed` that are based on GitHub's color palette and themes of the
-same names. If you want to know the specific colors used in each of these,
+At the present time, there are nine built-in themes that are based 
+on GitHub's color palette and themes of the same names. If you want to 
+know the specific colors used in each of these,
 see the source in [src/Colors.py](src/Colors.py). Also see 
 the [Example Workflows and Image Samples](#example-workflows-and-image-samples)
 section of this readme for a few samples.
 
 The default is `colors: light`. You can change to a different color theme
-by just passing its name (e.g., `colors: dark`).
+by just passing its name (e.g., `colors: dark`). Here is a list of the 
+currently supported built-in themes:
+
+| Theme Name |
+| --- |
+| `dark` |
+| `dark-colorblind` |
+| `dark-dimmed` |
+| `dark-high-contrast` |
+| `dark-tritanopia` |
+| `light` |
+| `light-colorblind` |
+| `light-high-contrast` |
+| `light-tritanopia` |
+
+Note that at the present time a couple of these are identical. For example,
+`light`, `light-colorblind`, and `light-tritanopia` are currently identical 
+because the part of GitHub's color palettes from which these themes derive
+do not differ. They have been included as valid values for the `colors` input
+to the action for consistency.
 
 If you have a specific set of colors that you'd like to instead use, you
 can pass a list of colors (space or comma separated). The list should include

--- a/src/ColorUtil.py
+++ b/src/ColorUtil.py
@@ -28,7 +28,7 @@ def isValidColor(color) :
     """Checks if a color is a valid color.
 
     Keyword arguments:
-    color - The color to check, either in hex or as a named color.
+    color - The color to check, either in hex or as a named color or as an rgba().
     """
     validHexDigits = set("0123456789abcdefABCDEF")
     color = color.strip()
@@ -36,8 +36,49 @@ def isValidColor(color) :
         if len(color) != 4 and len(color) != 7 :
             return False
         return all(c in validHexDigits for c in color[1:])
+    elif color.startswith("rgba(") :
+        return strToRGBA(color) != None
     else :
         return color in _namedColors
+
+def strToRGBA(color) :
+    """Converts a str specifying rgba color to
+    r, g, b, and a channels. Returns (r, g, b, a) is valid
+    and otherwise returns None.
+
+    Keyword arguments:
+    color - a str of the form: rgba(r,g,b,a).
+    """
+    if color.startswith("rgba(") :
+        last = color.find(")")
+        if last > 5 :
+            rgba = color[5:last].split(",")
+            if len(rgba) == 4 :
+                try :
+                    r = int(rgba[0])
+                    g = int(rgba[1])
+                    b = int(rgba[2])
+                    a = float(rgba[3])
+                except ValueError :
+                    return None
+                if r >= 256 :
+                    r = 255
+                if g >= 256 :
+                    g = 255
+                if b >= 256 :
+                    b = 255
+                if r < 0 :
+                    r = 0
+                if g < 0 :
+                    g = 0
+                if b < 0 :
+                    b = 0
+                if a < 0.0 :
+                    a = 0.0
+                if a > 1.0 :
+                    a = 1.0
+                return r, g, b, a
+    return None
 
 def highContrastingColor(color) :
     """Computes a highly contrasting color.
@@ -82,23 +123,33 @@ def luminance(color) :
     color - The color, either in hex or as a named color.
     """
     color = color.strip()
-    if not color.startswith("#") :
-        if color not in _namedColors :
+    if color.startswith("rgba(") :
+        rgba = strToRGBA(color)
+        if rgba != None :
+            r, g, b, a = rgba
+        else :
             return None
-        color = _namedColors[color]
-    if len(color) == 4 :
-        r = color[1] + color[1]
-        g = color[2] + color[2]
-        b = color[3] + color[3]
-    elif len(color) == 7 :
-        r = color[1:3]
-        g = color[3:5]
-        b = color[5:7]
-    else:
-        return None
-    r = _sRGBtoLin(int(r, base=16) / 255)
-    g = _sRGBtoLin(int(g, base=16) / 255)
-    b = _sRGBtoLin(int(b, base=16) / 255)
+    else :
+        if not color.startswith("#") :
+            if color not in _namedColors :
+                return None
+            color = _namedColors[color]
+        if len(color) == 4 :
+            r = color[1] + color[1]
+            g = color[2] + color[2]
+            b = color[3] + color[3]
+        elif len(color) == 7 :
+            r = color[1:3]
+            g = color[3:5]
+            b = color[5:7]
+        else:
+            return None
+        r = int(r, base=16)
+        g = int(g, base=16)
+        b = int(b, base=16)
+    r = _sRGBtoLin(r / 255)
+    g = _sRGBtoLin(g / 255)
+    b = _sRGBtoLin(b / 255)
     return 0.2126 * r + 0.7152 * g + 0.0722 * b
 
 def _sRGBtoLin(c) :

--- a/src/Colors.py
+++ b/src/Colors.py
@@ -148,6 +148,15 @@ colorMapping = {
         "icons" : "#0349b4",
         "text" : "#0E1116",
         "title" : "#0349b4"
+        },
+
+    # Contributor: cicirello (updated theme set)
+    "light-tritanopia" : {
+        "bg" : "#f6f8fa",
+        "border" : "rgba(84,174,255,0.4)",
+        "icons" : "#0969da",
+        "text" : "#24292f",
+        "title" : "#0969da"
         }
     
     }

--- a/src/Colors.py
+++ b/src/Colors.py
@@ -87,6 +87,15 @@ colorMapping = {
         "title" : "#58a6ff"
         },
 
+    # Contributor: cicirello (updated theme set)
+    "dark-colorblind" : {
+        "bg" : "#010409",
+        "border" : "rgba(56,139,253,0.4)",
+        "icons" : "#1f6feb",
+        "text" : "#c9d1d9",
+        "title" : "#58a6ff"
+        },
+
     # Contributor: cicirello (part of initial theme set)
     "dark-dimmed" : {
         "bg" : "#1c2128",

--- a/src/Colors.py
+++ b/src/Colors.py
@@ -35,7 +35,7 @@
 #
 # Specifically, from the link above we use:
 # * background color (bg): canvas.inset
-# * border color: accent.emphasis
+# * border color: accent.muted
 # * icons: accent.emphasis
 # * text: fg.default                      
 # * title: accent.fg
@@ -81,7 +81,7 @@ colorMapping = {
     # Contributor: cicirello (part of initial theme set)
     "dark" : {
         "bg" : "#010409",
-        "border" : "#1f6feb",
+        "border" : "rgba(56,139,253,0.4)",
         "icons" : "#1f6feb",
         "text" : "#c9d1d9",
         "title" : "#58a6ff"
@@ -90,7 +90,7 @@ colorMapping = {
     # Contributor: cicirello (part of initial theme set)
     "dark-dimmed" : {
         "bg" : "#1c2128",
-        "border" : "#316dca",
+        "border" : "rgba(65,132,228,0.4)",
         "icons" : "#316dca",
         "text" : "#adbac7",
         "title" : "#539bf5"
@@ -99,7 +99,7 @@ colorMapping = {
     # Contributor: cicirello (part of initial theme set)
     "light" : {
         "bg" : "#f6f8fa",
-        "border" : "#0969da",
+        "border" : "rgba(84,174,255,0.4)",
         "icons" : "#0969da",
         "text" : "#24292f",
         "title" : "#0969da"

--- a/src/Colors.py
+++ b/src/Colors.py
@@ -36,7 +36,7 @@
 # Specifically, from the link above we use:
 # * background color (bg): canvas.inset
 # * border color: accent.emphasis
-# * icons: accent.fg
+# * icons: accent.emphasis
 # * text: fg.default                      
 # * title: accent.fg
 #
@@ -82,7 +82,7 @@ colorMapping = {
     "dark" : {
         "bg" : "#010409",
         "border" : "#1f6feb",
-        "icons" : "#58a6ff",
+        "icons" : "#1f6feb",
         "text" : "#c9d1d9",
         "title" : "#58a6ff"
         },
@@ -91,7 +91,7 @@ colorMapping = {
     "dark-dimmed" : {
         "bg" : "#1c2128",
         "border" : "#316dca",
-        "icons" : "#539bf5",
+        "icons" : "#316dca",
         "text" : "#adbac7",
         "title" : "#539bf5"
         },

--- a/src/Colors.py
+++ b/src/Colors.py
@@ -1,7 +1,7 @@
 #
 # user-statistician: Github action for generating a user stats card
 # 
-# Copyright (c) 2021 Vincent A Cicirello
+# Copyright (c) 2021-2022 Vincent A Cicirello
 # https://www.cicirello.org/
 #
 # MIT License
@@ -38,7 +38,7 @@
 # * border color: accent.emphasis
 # * icons: accent.fg
 # * text: fg.default                      
-# * title: fg.default
+# * title: accent.fg
 #
 # Notes to Potential Contributors:
 #
@@ -84,7 +84,7 @@ colorMapping = {
         "border" : "#1f6feb",
         "icons" : "#58a6ff",
         "text" : "#c9d1d9",
-        "title" : "#c9d1d9"
+        "title" : "#58a6ff"
         },
 
     # Contributor: cicirello (part of initial theme set)
@@ -93,7 +93,7 @@ colorMapping = {
         "border" : "#316dca",
         "icons" : "#539bf5",
         "text" : "#adbac7",
-        "title" : "#adbac7"
+        "title" : "#539bf5"
         },
 
     # Contributor: cicirello (part of initial theme set)
@@ -102,7 +102,7 @@ colorMapping = {
         "border" : "#0969da",
         "icons" : "#0969da",
         "text" : "#24292f",
-        "title" : "#24292f"
+        "title" : "#0969da"
         }
     
     }

--- a/src/Colors.py
+++ b/src/Colors.py
@@ -114,6 +114,15 @@ colorMapping = {
         "title" : "#71b7ff"
         },
 
+    # Contributor: cicirello (updated theme set)
+    "dark-tritanopia" : {
+        "bg" : "#010409",
+        "border" : "rgba(56,139,253,0.4)",
+        "icons" : "#1f6feb",
+        "text" : "#c9d1d9",
+        "title" : "#58a6ff"
+        },
+
     # Contributor: cicirello (part of initial theme set)
     "light" : {
         "bg" : "#f6f8fa",

--- a/src/Colors.py
+++ b/src/Colors.py
@@ -124,6 +124,15 @@ colorMapping = {
         },
 
     # Contributor: cicirello (updated theme set)
+    "light-colorblind" : {
+        "bg" : "#f6f8fa",
+        "border" : "rgba(84,174,255,0.4)",
+        "icons" : "#0969da",
+        "text" : "#24292f",
+        "title" : "#0969da"
+        },
+
+    # Contributor: cicirello (updated theme set)
     "light-high-contrast" : {
         "bg" : "#ffffff",
         "border" : "#368cf9",

--- a/src/Colors.py
+++ b/src/Colors.py
@@ -96,6 +96,15 @@ colorMapping = {
         "title" : "#539bf5"
         },
 
+    # Contributor: cicirello (updated theme set)
+    "dark-high-contrast" : {
+        "bg" : "#010409",
+        "border" : "#409eff",
+        "icons" : "#409eff",
+        "text" : "#f0f3f6",
+        "title" : "#71b7ff"
+        },
+
     # Contributor: cicirello (part of initial theme set)
     "light" : {
         "bg" : "#f6f8fa",

--- a/src/Colors.py
+++ b/src/Colors.py
@@ -112,6 +112,15 @@ colorMapping = {
         "icons" : "#0969da",
         "text" : "#24292f",
         "title" : "#0969da"
+        },
+
+    # Contributor: cicirello (updated theme set)
+    "light-high-contrast" : {
+        "bg" : "#ffffff",
+        "border" : "#368cf9",
+        "icons" : "#0349b4",
+        "text" : "#0E1116",
+        "title" : "#0349b4"
         }
     
     }

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -160,7 +160,17 @@ class TestSomething(unittest.TestCase) :
         self._validateAllForks(stats)
 
     def test_color_themes(self) :
-        originalThemes = {"light", "dark", "dark-dimmed"}
+        originalThemes = {
+            "light",
+            "light-colorblind",
+            "light-high-contrast",
+            "light-tritanopia",
+            "dark",
+            "dark-colorblind",
+            "dark-dimmed",
+            "dark-high-contrast",
+            "dark-tritanopia"
+        }
         for theme in originalThemes :
             self._colorValidation(colorMapping[theme])
         for theme in colorMapping :


### PR DESCRIPTION
## Summary
Added new themes to correspond to all of GitHub's themes, including:
* dark-high-contrast
* light-high-contrast
* dark-colorblind
* light-colorblind
* dark-tritanopia
* light-tritanopia

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
