### PR TITLE
CI/CD: Remove paths exclusion on build workflow for PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,6 @@ on:
     paths-ignore: [ '**.svg', '**.md' ]
   pull_request:
     branches: [ main ]
-    paths-ignore: [ '**.svg', '**.md' ]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
The build.yml was configured to NOT run if the only files changed were md and svg. The md exclusion was problematic if PR is only editing the README since that build workflow was set as a required PR check.
