### PR TITLE
Fix language chart radius calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2022-09-08
+## [Unreleased] - 2022-09-09
 
 ### Added
 
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Dependencies
+
+
+## [1.16.1] - 2022-09-09
+
+### Fixed
+* Corrected minor error in language chart radius calculation that was causing too small margin around chart for users with long names.
 
 
 ## [1.16.0] - 2022-09-08

--- a/src/StatsImageGenerator.py
+++ b/src/StatsImageGenerator.py
@@ -161,7 +161,7 @@ class StatsImageGenerator :
         self._firstColX = (self._width // 2)
         self._secondColX = self._firstColX + (self._width // 4) 
         self._lineHeight = 21
-        self._pieRadius = (((self._width // 2 - self._margin) // self._lineHeight * self._lineHeight) - (self._lineHeight - 16)) // 2 
+        self._pieRadius = (((self._width // 2 - 2*self._margin) // self._lineHeight * self._lineHeight) - (self._lineHeight - 16)) // 2 
         self._rows = [
             StatsImageGenerator.headerTemplate,
             StatsImageGenerator.backgroundTemplate,

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -306,9 +306,10 @@ class TestSomething(unittest.TestCase) :
                     )
                 self.parsePriorYearStats(executedQueryResults[3])
         stats = NoQueries(True, False, 100, set(), "FavoriteRepo")
+        #stats._name = "Firstname ReallyLongMiddleName Lastname"
         #categories = ["general", "repositories", "languages", "contributions"]
         categories = categoryOrder[:]
-        colors = copy.deepcopy(colorMapping["batty"])
+        colors = copy.deepcopy(colorMapping["halloween"])
         #colors["title-icon"] = "pumpkin"
         svgGen = StatsImageGenerator(
             stats,


### PR DESCRIPTION
## Summary
Corrected minor error in language chart radius calculation that was causing too small margin around chart for users with long names.

## Closing Issues
Closes #144 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
