### PR TITLE
Replaced use of GitHub Action's deprecated set-output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+* Replaced the usage of GitHub Action's deprecated `set-output` with the new `$GITHUB_OUTPUT` env file.
 
 ### Dependencies
 * Bump cicirello/pyaction from 4.10.0 to 4.11.0

--- a/src/Statistician.py
+++ b/src/Statistician.py
@@ -27,6 +27,18 @@
 
 import json
 import subprocess
+import os
+
+def set_outputs(names_values) :
+    """Sets the GitHub Action outputs.
+
+    Keyword arguments:
+    names_values - Dictionary of output names with values
+    """
+    if "GITHUB_OUTPUT" in os.environ :
+        with open(os.environ["GITHUB_OUTPUT"], "a") as f :
+            for name, value in names_values.items() :
+                print("{0}={1}".format(name, value), file=f)
 
 class Statistician :
     """The Statistician class executes GitHub GraphQl queries,
@@ -128,7 +140,7 @@ class Statistician :
                 return file.read()
         except IOError:
             print("Error (1): Failed to open query file:", queryFilePath)
-            print("::set-output name=exit-code::1")
+            set_outputs({"exit-code" : 1})
             exit(1 if failOnError else 0)
 
     def parseStats(self, basicStats, repoStats, watchingStats, reposContributedToStats) :
@@ -427,12 +439,11 @@ class Statistician :
             if "errors" in result :
                 print("Error (2): GitHub api Query failed with error:")
                 print(result["errors"])
-                print("::set-output name=exit-code::2")
                 code = 2
             else :
                 print("Error (3): Something unexpected occurred during GitHub API query.")
-                print("::set-output name=exit-code::3")
                 code = 3
+            set_outputs({"exit-code" : code})
             exit(code if failOnError else 0)
         elif needsPagination :
             if (numPages > 1) :
@@ -453,7 +464,7 @@ class Statistician :
             print("Error (6): No data returned.")
             if errorMessage != None :
                 print(errorMessage)
-            print("::set-output name=exit-code::6")
+            set_outputs({"exit-code" : 6})
             exit(6 if failOnError else 0)
         return result
 

--- a/src/UserStatistician.py
+++ b/src/UserStatistician.py
@@ -26,7 +26,7 @@
 # SOFTWARE.
 #
 
-from Statistician import Statistician
+from Statistician import Statistician, set_outputs
 from Colors import colorMapping, iconTemplates
 from StatsImageGenerator import StatsImageGenerator
 from StatConfig import supportedLocales, categoryOrder
@@ -61,7 +61,7 @@ def writeImageToFile(filename, image, failOnError) :
             file.write(image)
     except IOError:
         print("Error (4): An error occurred while writing the image to a file.")
-        print("::set-output name=exit-code::4")
+        set_outputs({"exit-code" : 4})
         exit(4 if failOnError else 0)
 
 def executeCommand(arguments) :
@@ -102,7 +102,7 @@ def commitAndPush(filename, name, login, failOnError) :
             r = executeCommand(["git", "push"])
             if r[1] != 0 :
                 print("Error (5): push failed.")
-                print("::set-output name=exit-code::5")
+                set_outputs({"exit-code" : 5})
                 exit(5 if failOnError else 0)
     
 
@@ -213,5 +213,5 @@ if __name__ == "__main__" :
     if commit :
         commitAndPush(imageFilenameWithPath, "github-actions", "41898282+github-actions[bot]", failOnError)
     
-    print("::set-output name=exit-code::0")
+    set_outputs({"exit-code" : 0})
     


### PR DESCRIPTION
## Summary
Replaced the usage of GitHub Action's deprecated `set-output` with the new `$GITHUB_OUTPUT` env file.

## Closing Issues
Closes #183 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
