### PR TITLE
Backwards compatibility for self-hosted runners without support for new `GITHUB_OUTPUT` env file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2022-10-24
+## [Unreleased] - 2022-10-25
 
 ### Added
 * Translation to Odia (`locale: or`) in #186, contributed by @Prasanta-Hembram.
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+* Some users may be using the action on a self-hosted runner not yet updated to a version supporting the
+  new GitHub Actions `GITHUB_OUTPUT` env file. This patch adds backwards compatibility for that case by 
+  falling back to the deprecated `set-output` if `GITHUB_OUTPUT` doesn't exist. #190 (@cicirello).
 
 ### Dependencies
 * Bump cicirello/pyaction from 4.11.0 to 4.11.1

--- a/src/Statistician.py
+++ b/src/Statistician.py
@@ -39,6 +39,9 @@ def set_outputs(names_values) :
         with open(os.environ["GITHUB_OUTPUT"], "a") as f :
             for name, value in names_values.items() :
                 print("{0}={1}".format(name, value), file=f)
+    else : # Fall-back to deprecated set-output for self-hosted runners
+        for name, value in names_values.items() :
+            print("::set-output name={0}::{1}".format(name, value))
 
 class Statistician :
     """The Statistician class executes GitHub GraphQl queries,


### PR DESCRIPTION
## Summary
Some users may be using the action on a self-hosted runner not yet updated to a version supporting the new GitHub Actions `GITHUB_OUTPUT` env file. This patch adds backwards compatibility for that case by falling back to the deprecated `set-output` if `GITHUB_OUTPUT` doesn't exist.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
