### PR TITLE
Bump Python to 3.11 in CI/CD workflows and in Docker container

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.11'
 
     - name: Run Python unit tests
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   falling back to the deprecated `set-output` if `GITHUB_OUTPUT` doesn't exist. #190 (@cicirello).
 
 ### Dependencies
-* Bump cicirello/pyaction from 4.11.0 to 4.11.1
+* Bump cicirello/pyaction from 4.11.0 to 4.12.0, including upgrading Python within the Docker container to 3.11.
+
+### CI/CD
+* Bump Python to 3.11 in CI/CD workflows.
 
 
 ## [1.19.0] - 2022-10-20

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # Licensed under the MIT License
 
 # The base image is pyaction, which is python slim, plus the GitHub CLI (gh).
-FROM ghcr.io/cicirello/pyaction:4.11.1
+FROM ghcr.io/cicirello/pyaction:4.12.0
 
 # Copy the GraphQl queries and python source into the container.
 COPY src /


### PR DESCRIPTION
## Summary
Upgrade to use Python 3.11.
