### PR TITLE
Fix background color of GitHub inspired themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+* Better match background for GitHub-inspired themes, using GitHub's canvas.default instead of canvas.inset.
 
 ### Dependencies
 

--- a/src/Colors.py
+++ b/src/Colors.py
@@ -34,7 +34,7 @@
 # https://primer.style/primitives/colors).
 #
 # Specifically, from the link above we use:
-# * background color (bg): canvas.inset
+# * background color (bg): canvas.default
 # * border color: accent.muted
 # * icons: accent.emphasis
 # * text: fg.default                      
@@ -89,7 +89,7 @@ colorMapping = {
     
     # Contributor: cicirello (part of initial theme set)
     "dark" : {
-        "bg" : "#010409",
+        "bg" : "#0d1117",
         "border" : "rgba(56,139,253,0.4)",
         "icons" : "#1f6feb",
         "text" : "#c9d1d9",
@@ -99,7 +99,7 @@ colorMapping = {
 
     # Contributor: cicirello (updated theme set)
     "dark-colorblind" : {
-        "bg" : "#010409",
+        "bg" : "#0d1117",
         "border" : "rgba(56,139,253,0.4)",
         "icons" : "#1f6feb",
         "text" : "#c9d1d9",
@@ -109,7 +109,7 @@ colorMapping = {
 
     # Contributor: cicirello (part of initial theme set)
     "dark-dimmed" : {
-        "bg" : "#1c2128",
+        "bg" : "#22272e",
         "border" : "rgba(65,132,228,0.4)",
         "icons" : "#316dca",
         "text" : "#adbac7",
@@ -119,7 +119,7 @@ colorMapping = {
 
     # Contributor: cicirello (updated theme set)
     "dark-high-contrast" : {
-        "bg" : "#010409",
+        "bg" : "#0a0c10",
         "border" : "#409eff",
         "icons" : "#409eff",
         "text" : "#f0f3f6",
@@ -129,7 +129,7 @@ colorMapping = {
 
     # Contributor: cicirello (updated theme set)
     "dark-tritanopia" : {
-        "bg" : "#010409",
+        "bg" : "#0d1117",
         "border" : "rgba(56,139,253,0.4)",
         "icons" : "#1f6feb",
         "text" : "#c9d1d9",
@@ -159,7 +159,7 @@ colorMapping = {
 
     # Contributor: cicirello (part of initial theme set)
     "light" : {
-        "bg" : "#f6f8fa",
+        "bg" : "#ffffff",
         "border" : "rgba(84,174,255,0.4)",
         "icons" : "#0969da",
         "text" : "#24292f",
@@ -169,7 +169,7 @@ colorMapping = {
 
     # Contributor: cicirello (updated theme set)
     "light-colorblind" : {
-        "bg" : "#f6f8fa",
+        "bg" : "#ffffff",
         "border" : "rgba(84,174,255,0.4)",
         "icons" : "#0969da",
         "text" : "#24292f",
@@ -189,7 +189,7 @@ colorMapping = {
 
     # Contributor: cicirello (updated theme set)
     "light-tritanopia" : {
-        "bg" : "#f6f8fa",
+        "bg" : "#ffffff",
         "border" : "rgba(84,174,255,0.4)",
         "icons" : "#0969da",
         "text" : "#24292f",

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -309,7 +309,7 @@ class TestSomething(unittest.TestCase) :
         #stats._name = "Firstname ReallyLongMiddleName Lastname"
         #categories = ["general", "repositories", "languages", "contributions"]
         categories = categoryOrder[:]
-        colors = copy.deepcopy(colorMapping["halloween"])
+        colors = copy.deepcopy(colorMapping["dark"])
         #colors["title-icon"] = "pumpkin"
         svgGen = StatsImageGenerator(
             stats,


### PR DESCRIPTION
## Summary
Better match background for GitHub-inspired themes, by using GitHub's canvas.default instead of canvas.inset for the background color for all of the GitHub inspired themes. 

## Closing Issues
Closes #200 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
