### PR TITLE
Get repository owner (user for stats image) from GitHub Actions environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2023-01-27
+## [Unreleased] - 2023-02-14
 
 ### Added
 
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+* Get repository owner (user for stats image) from GitHub Actions environment variables (fixes issue with latest GitHub CLI with current approach of leaving it to CLI to determine owner of repository). 
 
 ### Dependencies
 * Bump cicirello/pyaction from 4.14.0 to 4.15.0

--- a/src/Statistician.py
+++ b/src/Statistician.py
@@ -1,7 +1,7 @@
 #
 # user-statistician: Github action for generating a user stats card
 # 
-# Copyright (c) 2021-2022 Vincent A Cicirello
+# Copyright (c) 2021-2023 Vincent A Cicirello
 # https://www.cicirello.org/
 #
 # MIT License
@@ -422,9 +422,15 @@ class Statistician :
             query; and if False, this action will quietly exit with no error code. In
             either case, an error message will be logged to the console.
         """
+        if "GITHUB_REPOSITORY_OWNER" in os.environ :
+            owner = os.environ["GITHUB_REPOSITORY_OWNER"]
+        else :
+            print("Error (7): Could not determine the repository owner.")
+            set_outputs({"exit-code" : 7})
+            exit(7 if failOnError else 0)
         arguments = [
             'gh', 'api', 'graphql',
-            '-F', 'owner={owner}',
+            '-F', 'owner=' + owner,
             '--cache', '1h',
             '-f', 'query=' + query
             ]


### PR DESCRIPTION
## Summary
Get repository owner (user for stats image) from GitHub Actions environment variables (fixes issue with latest GitHub CLI with current approach of leaving it to CLI to determine owner of repository).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
