### PR TITLE
Enable customizing the commit message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2024-03-07
+## [Unreleased] - 2024-05-13
 
 ### Added
+* An action input, `commit-message`, to enable customizing the commit message
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -879,6 +879,11 @@ that has configured required reviews or required checks:
 
 The author of the commit is set to the github-actions bot.
 
+### `commit-message`
+
+The `commit-message` input enables customizing the commit message. The
+default is `commit-message: 'Automated change by https://github.com/cicirello/user-statistician'`.
+
 ## Outputs
 
 The action has only the following action output variable.
@@ -939,6 +944,7 @@ jobs:
         locale: en
         fail-on-error: true
         commit-and-push: true
+        commit-message: 'Automated change by https://github.com/cicirello/user-statistician'
       env:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 # user-statistician: Github action for generating a user stats card
 # 
-# Copyright (c) 2021-2022 Vincent A Cicirello
+# Copyright (c) 2021-2024 Vincent A Cicirello
 # https://www.cicirello.org/
 #
 # MIT License
@@ -58,7 +58,7 @@ inputs:
     required: false
     default: true
   locale:
-    description: 'ISO 639-1 two character language code'
+    description: 'One of the supported ISO 639-1 (two character) or ISO 639-2 (three character) language codes'
     required: false
     default: en
   border-radius:
@@ -105,6 +105,10 @@ inputs:
     description: 'Icon displayed at top of SVG to left and right of title'
     required: false
     default: default
+  commit-message: 
+    description: 'The commit message'
+    required: false
+    default: 'Automated change by https://github.com/cicirello/user-statistician'
 outputs:
   exit-code:
     description: '0 if successful or non-zero if unsuccessful'
@@ -131,3 +135,4 @@ runs:
     - ${{ inputs.language-animation-speed }}
     - ${{ inputs.image-width }}
     - ${{ inputs.top-icon }}
+    - ${{ commit-message }}

--- a/action.yml
+++ b/action.yml
@@ -135,4 +135,4 @@ runs:
     - ${{ inputs.language-animation-speed }}
     - ${{ inputs.image-width }}
     - ${{ inputs.top-icon }}
-    - ${{ commit-message }}
+    - ${{ inputs.commit-message }}

--- a/src/UserStatistician.py
+++ b/src/UserStatistician.py
@@ -2,7 +2,7 @@
 #
 # user-statistician: Github action for generating a user stats card
 # 
-# Copyright (c) 2021-2023 Vincent A Cicirello
+# Copyright (c) 2021-2024 Vincent A Cicirello
 # https://www.cicirello.org/
 #
 # MIT License
@@ -77,13 +77,15 @@ def executeCommand(arguments):
         )
     return result.stdout.strip(), result.returncode
 
-def commitAndPush(filename, name, login, failOnError):
+def commitAndPush(filename, name, login, failOnError, commit_message):
     """Commits and pushes the image.
 
     Keyword arguments:
     filename - The path to the image.
     name - The user's name.
     login - The user's login id.
+    failOnError - Boolean controlling whether or not to fail the run if an error occurs.
+    commit_message - Message for the commit
     """
     # Resolve issue related to user in Docker container vs owner of repository
     executeCommand(
@@ -104,7 +106,7 @@ def commitAndPush(filename, name, login, failOnError):
                  login + '@users.noreply.github.com'])
             executeCommand(["git", "add", filename])
             executeCommand(["git", "commit", "-m",
-                            "Automated change by https://github.com/cicirello/user-statistician",
+                            commit_message,
                            filename])
             r = executeCommand(["git", "push"])
             if r[1] != 0:
@@ -193,6 +195,8 @@ if __name__ == "__main__":
         colors.pop("title-icon", None)
     elif topIcon != "default" and topIcon in iconTemplates:
         colors["title-icon"] = topIcon
+
+    commit_message = sys.argv[20].strip()
         
     stats = Statistician(
         failOnError,
@@ -223,7 +227,8 @@ if __name__ == "__main__":
             imageFilenameWithPath,
             "github-actions",
             "41898282+github-actions[bot]",
-            failOnError)
+            failOnError,
+            commit_message)
     
     set_outputs({"exit-code" : 0})
     


### PR DESCRIPTION
## Summary
Enable customizing the commit message, with a new action input, `commit-message`

## Closing Issues
Closes #253 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
