### PR TITLE
fetch pull request review count from REST API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2026-07-20
+## [Unreleased] - 2026-07-21
 
 ### Added
 
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+* Fetch total number of pull request reviews from the REST API
 
 ### Dependencies
 

--- a/src/Statistician.py
+++ b/src/Statistician.py
@@ -116,6 +116,7 @@ class Statistician:
                               failOnError=fail,
                               queryName="repostats"),
             totalCommits = self.fetchTotalCommits(),
+            totalReviews = self.fetchTotalPullRequestReviews(),
             contribToData = self.executeOptionalQuery(reposContributedToQuery, 
                             queryName="basicstats2")
         )
@@ -161,6 +162,7 @@ class Statistician:
         repoStats, 
         reposContributedToStats = None,
         totalCommits = None,
+        totalReviews = None,
         contribToData = None):
         """Parses the user statistics.
 
@@ -243,8 +245,8 @@ class Statistician:
                 totalCommits == None) else [pastYearData["totalCommitContributions"], totalCommits],
             "issues" : [pastYearData["totalIssueContributions"], issues],
             "prs" : [pastYearData["totalPullRequestContributions"], pullRequests],
-            #"reviews" : [pastYearData["totalPullRequestReviewContributions"], 0],
-            "reviews" : [pastYearData["totalPullRequestReviewContributions"]],
+            "reviews" : [pastYearData["totalPullRequestReviewContributions"]] if (
+                totalReviews == None) else [pastYearData["totalPullRequestReviewContributions"], totalReviews],
             # See comment above for reason for this change.
             #"contribTo" : [pastYearData["repositoriesContributedTo"], repositoriesContributedTo],
             "contribTo" : [pastYearData["repositoriesContributedTo"]],
@@ -498,8 +500,36 @@ class Statistician:
             yr["contributionsCollection"]["restrictedContributionsCount"] for yr in yearlyQueryResults
         )
     
+    def fetchTotalPullRequestReviews(self):
+        """Queries the REST API for the total number of pull request reviews.
+        """
+        if "GITHUB_REPOSITORY_OWNER" in os.environ:
+            owner = os.environ["GITHUB_REPOSITORY_OWNER"]
+        else:
+            print("Error (7): Could not determine the repository owner.")
+            set_outputs({"exit-code" : 7})
+            exit(7 if failOnError else 0)
+        arguments = [
+            'gh', 'api', '-X', 'GET', 'search/issues',
+            '-f', f"q=is:pr reviewed-by:{owner}",
+            '-f', "per_page=1", 
+            '--cache', '1h', 
+            '--jq', '.total_count'
+        ]
+        result = subprocess.run(
+            arguments,
+            stdout=subprocess.PIPE,
+            universal_newlines=True
+            ).stdout.strip()
+        try:
+            num_reviews = int(result)
+            return num_reviews if num_reviews > 0 else None
+        except ValueError:
+            print(f"❌ For total PR Reviews, REST API returned: {result}.")
+            return None
+    
     def fetchTotalCommits(self):
-        """Queries te REST API for the total number of commits.
+        """Queries the REST API for the total number of commits.
         """
         if "GITHUB_REPOSITORY_OWNER" in os.environ:
             owner = os.environ["GITHUB_REPOSITORY_OWNER"]


### PR DESCRIPTION
## Summary
Fetch pull request review count from REST API. We were previously getting this via the GraphQL API by querying the contributionsCollection once for each year the user has been on GitHub and summing over those results. We removed this count as a temporary patch related to resource limits errors on certain GraphQL queries that began on or about July 16, 2026. This REST API query resolves the issue for this specific data. It doesn't close the corresponding issue as there is another query that currently fails for some users.

## Closing Issues
This is part of #315, but it does not close it.

## Pull Request Requirements 
If you are unable to check everything in this list, your pull request will be closed:
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My pull request has a corresponding Issue and I linked to it above in the [Closing Issues](#closing-issues) section.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
